### PR TITLE
Implemented custom_json DAU for votes

### DIFF
--- a/src/_g.ts
+++ b/src/_g.ts
@@ -34,6 +34,7 @@ export const data_type = {
   dau_transfers: 'dau_transfers',
   dau_meta: 'dau_meta',
   dau_custom: 'dau_custom',
+  dau_vote_general: 'dau_vote_general',
   dau_total: 'dau_total',
   tx_meta: 'tx_meta',
   rewards_benefactor_sbd: 'rewards_benefactor_sbd',

--- a/src/database/data.db.ts
+++ b/src/database/data.db.ts
@@ -100,7 +100,7 @@ export let create_or_add = async (external: boolean, app: string, data_type: str
 export let create_total_dau = async (app: string) => {
   let data = []
   // Get all data from accounts and group based on date
-  for(let data_type of [_g.data_type.dau_custom, _g.data_type.dau_meta, _g.data_type.dau_transfers, _g.data_type.dau_benefactor]) {
+  for(let data_type of [_g.data_type.dau_custom, _g.data_type.dau_meta, _g.data_type.dau_transfers, _g.data_type.dau_benefactor, _g.data_type.dau_vote_general]) {
     let data_db = await find_intern(app, '', data_type)
     for (let d of data_db) {
       data = data.concat(d.data)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import { update_rank } from './main/update/rank'
 import { convert_accepted_submissions } from './main/submission/accept'
 import { query } from './main/queries/query'
 
+import * as dau_query from './main/queries/dau'
+
 import * as db_app from './database/app.db'
 import * as db_data from './database/data.db'
 
@@ -31,9 +33,6 @@ export let start = async () => {
     }
 
     // await format_accounts()
-    // Create the initial Apps
-    // console.log('create_initial_apps')
-    // await create_initial_apps()
     
     main()
 
@@ -87,7 +86,6 @@ let main = async () => {
 
         // Update the data from approved Apps
         console.log('update_data')
-
         await update_data()
 
         // Set the data from approved Apps

--- a/src/main/queries/rewards.ts
+++ b/src/main/queries/rewards.ts
@@ -1,12 +1,12 @@
 import * as db_data from '../../database/data.db'
 
-import { query, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
+import { query, TIME_GROUP_ORDER_QUERY, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
 
 export let rewards_benefactor = async (app: string, account: string, asset: string, last_update) => {
   try {
     console.log(`REWARDS_BENEFACTOR_${asset}`)
     const column_name = (asset.toLowerCase() === 'vests' ? 'vesting' : asset.toLowerCase()) + '_payout'
-    let q = `SELECT SUM(${column_name}), ${TIMESTAMP()} FROM VOCommentBenefactorRewards WHERE[benefactor] = '${account}' AND ${column_name} > 0 ${TIME_GROUP_QUERY(last_update)}`
+    let q = `SELECT SUM(${column_name}), ${TIMESTAMP()} FROM VOCommentBenefactorRewards WHERE[benefactor] = '${account}' AND ${column_name} > 0 ${TIME_GROUP_ORDER_QUERY(last_update)}`
     const result = await query(q)
     const data_type = `REWARDS_BENEFACTOR_${asset}`.toLowerCase()
     const data = convert_grouped(result)
@@ -19,7 +19,7 @@ export let rewards_benefactor = async (app: string, account: string, asset: stri
 export let rewards_curation = async (app: string, account: string, last_update) => {
   try {
     console.log(`REWARDS_CURATION`)
-    let q = `SELECT SUM(CONVERT(FLOAT, LEFT(reward, LEN(reward)-6))), ${TIMESTAMP()} FROM VOCurationRewards WHERE[curator] = '${account}' ${TIME_GROUP_QUERY(last_update)}`
+    let q = `SELECT SUM(CONVERT(FLOAT, LEFT(reward, LEN(reward)-6))), ${TIMESTAMP()} FROM VOCurationRewards WHERE[curator] = '${account}' ${TIME_GROUP_ORDER_QUERY(last_update)}`
     //console.log(q)
     const result = await query(q)
     const data_type = `REWARDS_CURATION`.toLowerCase()

--- a/src/main/queries/tx.ts
+++ b/src/main/queries/tx.ts
@@ -2,7 +2,7 @@ import * as db_data from '../../database/data.db'
 
 import { create_arr_of_arrays, create_grouped_array, create_sum_array_of_group } from '../../helpers/convert'
 
-import { query, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
+import { query, TIME_GROUP_ORDER_QUERY, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
 
 /**
  * TX of transfers to account
@@ -11,8 +11,8 @@ export let tx_transfers = async (app: string, account: string, asset: string, la
   try {
     let THRESHOLD = process.env.TRANSFER_THRESHOLD
     console.log(`TX_TRANSFERS_${asset}`)
-    let query_incoming = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' AND amount >= ${THRESHOLD} ${TIME_GROUP_QUERY(last_update)}`
-    let query_outgoing = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxTransfers WHERE[from] = '${account}' AND amount_symbol = '${asset}' AND amount >= ${THRESHOLD} ${TIME_GROUP_QUERY(last_update)}`
+    let query_incoming = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' AND amount >= ${THRESHOLD} ${TIME_GROUP_ORDER_QUERY(last_update)}`
+    let query_outgoing = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxTransfers WHERE[from] = '${account}' AND amount_symbol = '${asset}' AND amount >= ${THRESHOLD} ${TIME_GROUP_ORDER_QUERY(last_update)}`
 
     const result_incoming = await query(query_incoming)
     const result_outgoing = await query(query_outgoing)
@@ -37,7 +37,7 @@ export let tx_transfers = async (app: string, account: string, asset: string, la
 export let tx_custom = async (app: string, custom_string: string, last_update) => {
   try {
     console.log(`TX_CUSTOM`)
-    let q = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxCustoms WHERE left(tid, ${custom_string.length}) = '${custom_string}' ${TIME_GROUP_QUERY(last_update)}`
+    let q = `SELECT COUNT(*), ${TIMESTAMP()} FROM TxCustoms WHERE left(tid, ${custom_string.length}) = '${custom_string}' ${TIME_GROUP_ORDER_QUERY(last_update)}`
     const result = await query(q)
     const data_type = `TX_CUSTOM`.toLowerCase()
     const data = convert_grouped(result)
@@ -50,7 +50,7 @@ export let tx_custom = async (app: string, custom_string: string, last_update) =
 export let tx_meta = async (app: string, meta_name: string, last_update) => {
   try {
     console.log(`TX_META`)
-    let q = `SELECT COUNT(*), ${TIMESTAMP('created')} FROM Comments WHERE ISJSON(json_metadata) > 0 AND SUBSTRING(JSON_VALUE(json_metadata, '$.app'), 0, ${meta_name.length + 1}) = '${meta_name}' ${TIME_GROUP_QUERY(last_update, 'created')}`
+    let q = `SELECT COUNT(*), ${TIMESTAMP('created')} FROM Comments WHERE ISJSON(json_metadata) > 0 AND SUBSTRING(JSON_VALUE(json_metadata, '$.app'), 0, ${meta_name.length + 1}) = '${meta_name}' ${TIME_GROUP_ORDER_QUERY(last_update, 'created')}`
     const result = await query(q)
     const data_type = `TX_META`.toLowerCase()
     const data = convert_grouped(result)

--- a/src/main/queries/volume.ts
+++ b/src/main/queries/volume.ts
@@ -1,6 +1,6 @@
 import * as db_data from '../../database/data.db'
 
-import { query, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
+import { query, TIME_GROUP_ORDER_QUERY, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
 
 /**
  * Sum of all transfers to account
@@ -8,7 +8,7 @@ import { query, TIME_GROUP_QUERY, TIMESTAMP, convert_grouped } from './query'
 export let volume_transfers = async (app: string, account: string, asset: string, last_update) => {
   try {
     console.log(`VOLUME_TRANSFERS_${asset}`)
-    let q = `SELECT SUM(amount), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' ${TIME_GROUP_QUERY(last_update)}`
+    let q = `SELECT SUM(amount), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' ${TIME_GROUP_ORDER_QUERY(last_update)}`
     const result = await query(q)
     const data_type = `VOLUME_TRANSFERS_${asset}`.toLowerCase()
     const data = convert_grouped(result)
@@ -21,5 +21,5 @@ export let volume_transfers = async (app: string, account: string, asset: string
 
 export let volume_payouts = async (app: string, account: string, asset: string, last_update) => {
   console.log(`VOLUME_PAYOUTS_${asset}`)
-  let q = `SELECT SUM(amount), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' ${TIME_GROUP_QUERY(last_update)}`
+  let q = `SELECT SUM(amount), ${TIMESTAMP()} FROM TxTransfers WHERE[to] = '${account}' AND amount_symbol = '${asset}' ${TIME_GROUP_ORDER_QUERY(last_update)}`
 }

--- a/src/models/app.model.ts
+++ b/src/models/app.model.ts
@@ -19,6 +19,7 @@ const schema = new mongoose.Schema({
       transfer: { type: Boolean, default: false },
       transfer_only_dau: { type: Boolean, default: false },
       meta: { type: Boolean, default: false },
+      account_creator: { type: Boolean, default: false },
       delegation: { type: Boolean, default: false },
       posting: { type: Boolean, default: false },
       logo: { type: Boolean, default: false },

--- a/src/models/submission.model.ts
+++ b/src/models/submission.model.ts
@@ -14,6 +14,7 @@ const schema = new mongoose.Schema({
       curation: { type: Boolean, default: false },
       transfer: { type: Boolean, default: false },
       transfer_only_dau: { type: Boolean, default: false },
+      account_creator: { type: Boolean, default: false },
       meta: { type: Boolean, default: false },
       delegation: { type: Boolean, default: false },
       posting: { type: Boolean, default: false },


### PR DESCRIPTION
Apps can now create a custom_json to track usage for actions which weren't trackable before (such as vote in this case).

The structure must be like this for votes via a custom_json:
```
required_posting_auths: therealwolf
id: vote
json: {"account":"therealwolf","author":"someauthor","permlink":"somepermlink","app":"someapp"}
```

The `author, permlink & account` fields are optional and currently not being used, however `app` is mandatory as well as `id` and `required_posting_auths`.

---

Besides this, I've also made a few small improvements.